### PR TITLE
Added gitignore file and modified README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -8,15 +8,7 @@ To install these kindly refer to https://docs.npmjs.com/getting-started/installi
 
     1.) Clone this repo on your local system
 
-    2.) Using a terminal switch to the folder where this repo is cloned and install following modules from npm.
-
-        1.) Express  
-            sudo npm install express
-        2.) Cookie-parser  
-            sudo npm install cookie-parser
-        3.) Body-parser
-            sudo npm install body-parser
-            
+    2.) Using a terminal switch to the folder where this repo is cloned and run `npm install` to install dev-dependencies.
             
 Since now the System is Setup we can proceed to run the cart prototype 
 This Repo contains a dummy data in items.json and has a dummy frontend to display the working of Shopping cart.

--- a/package.json
+++ b/package.json
@@ -8,5 +8,10 @@
     "start": "node server.js"
   },
   "author": "Aditya Bansal",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "body-parser": "^1.17.1",
+    "cookie-parser": "^1.4.3",
+    "express": "^4.15.2"
+  }
 }


### PR DESCRIPTION
This PR adds `.gitignore` file to ignore `node_modules` folder as we don't need `node_modules` folder to pushed to remote. This is only required to the local machine for code to work. This is also a good practice to ignore `node_modules` folder during development phase as this save unnecessary upload/download of `node_modules`.
This also fixes the irrelevant steps of installing npm modules in `README.md`. One of the solution of this issue is to save npm modules in devDependencies of `pakage.json` file.